### PR TITLE
Fix for Django 1.6 regarding `django.conf.urls.defaults`

### DIFF
--- a/object_tools/options.py
+++ b/object_tools/options.py
@@ -1,6 +1,9 @@
 from django import forms
 from django.conf import settings
-from django.conf.urls.defaults import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.contrib.admin import helpers
 from django.core.exceptions import PermissionDenied
 from django.core.urlresolvers import reverse


### PR DESCRIPTION
On Django 1.6 `from django.conf.urls.defaults import ...` should be `from django.conf.urls import ...`. This small patch tries to import using the new path and reverts to the old path on error, so it should be compatible with older versions.
