### PR TITLE
replace deprecated Options.module_name with model_name, some tweak to change_list.html

### DIFF
--- a/object_tools/options.py
+++ b/object_tools/options.py
@@ -79,7 +79,7 @@ class ObjectTool(object):
         return media
 
     def reverse(self):
-        info = self.model._meta.app_label, self.model._meta.module_name, \
+        info = self.model._meta.app_label, self.model._meta.model_name, \
             self.name
         return reverse('object-tools:%s_%s_%s' % info)
 
@@ -87,7 +87,7 @@ class ObjectTool(object):
         """
         URL patterns for tool linked to _view method.
         """
-        info = self.model._meta.app_label, self.model._meta.module_name, \
+        info = self.model._meta.app_label, self.model._meta.model_name, \
             self.name
         urlpatterns = patterns('',
             url(r'^%s/$' % self.name,

--- a/object_tools/sites.py
+++ b/object_tools/sites.py
@@ -71,7 +71,7 @@ class ObjectTools(object):
             for object_tool in object_tools:
                 urlpatterns += patterns('',
                     url(r'^%s/%s/' % (model._meta.app_label,
-                        model._meta.module_name),
+                        model._meta.model_name),
                         include(object_tool.urls))
                 )
 

--- a/object_tools/templates/admin/change_list.html
+++ b/object_tools/templates/admin/change_list.html
@@ -36,19 +36,13 @@
 {% block bodyclass %}change-list{% endblock %}
 
 {% if not is_popup %}
-  {% block breadcrumbs %}
-    <div class="breadcrumbs">
-      <a href="../../">
-        {% trans "Home" %}
-      </a>
-       &rsaquo;
-       <a href="../">
-         {{ app_label|capfirst }}
-      </a>
-      &rsaquo;
-      {{ cl.opts.verbose_name_plural|capfirst }}
-    </div>
-  {% endblock %}
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+    &rsaquo; {{ cl.opts.verbose_name_plural|capfirst }}
+</div>
+{% endblock %}
 {% endif %}
 
 {% block coltype %}flex{% endblock %}
@@ -56,19 +50,20 @@
 {% block content %}
   <div id="content-main">
     {% block object-tools %}
-      {% if has_add_permission %}
-        <ul class="object-tools">
-          {% block object-tools-items %}
+      <ul class="object-tools">
+        {% if has_add_permission %}
+          <li>
+            <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
+              {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
+            </a>
+          </li>
+        {% endif %}
+        {% block object-tools-items %}
             {% object_tools cl.model user %}
-            <li>
-              <a href="add/{% if is_popup %}?_popup=1{% endif %}" class="addlink">
-                {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
-              </a>
-            </li>
-          {% endblock %}
+        {% endblock %}
         </ul>
-      {% endif %}
     {% endblock %}
+
     {% if cl.formset.errors %}
         <p class="errornote">
         {% blocktrans count cl.formset.errors|length as counter %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}


### PR DESCRIPTION
change_list.html:
    1. fix breadcrumbs not showing app_label in Django 1.7
    2. fix object tools not appearing issue when user don't have add permission
