### PR TITLE
Fix passing on verbosity level when creating permissions

### DIFF
--- a/object_tools/management/__init__.py
+++ b/object_tools/management/__init__.py
@@ -63,7 +63,7 @@ def _create_permissions(**kwargs):
 
 
 def create_permissions(app_config, verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs):
-    return _create_permissions(verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs)
+    return _create_permissions(verbosity=verbosity, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs)
 
 
 signals.post_migrate.connect(


### PR DESCRIPTION
This allows silencing the `Adding permission ..` messages in the output of automated tests.